### PR TITLE
chore(exit): more log visibility

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -14,6 +14,6 @@ rescue Exception => e
     Common::Logger::LoggerFactory.get_logger.error(e)
     Common::Logger::LoggerFactory.get_logger.error(e.backtrace)
   end
-  exit!(1)
+  exit(1)
 end
 exit(0)


### PR DESCRIPTION
## Summary
Seems `exit!` was hiding many useful error messages, such as menus that are displayed when required arguments are not present
