### PR TITLE
feat(pem): accept either secretKeyPath or secretKeyName & secretKeyData for AWS UserConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.rbc
 /.config
 .idea/
+.ignore/
 /coverage/
 /InstalledFiles
 /pkg/

--- a/configs/templates/user.env-aws.json
+++ b/configs/templates/user.env-aws.json
@@ -4,6 +4,8 @@
       "apiKey": "[env:AWS_ACCESS_KEY_ID]",
       "secretKey": "[env:AWS_SECRET_ACCESS_KEY]",
       "sessionToken": "[env:AWS_SESSION_TOKEN]",
+      "secretKeyName": "[env:AWS_SECRET_PEM_KEY_NAME]",
+      "secretKeyData": "[env:AWS_SECRET_PEM_KEY_DATA]",
       "secretKeyPath": "[env:AWS_SECRET_PEM_KEY_PATH]",
       "region": "[env:AWS_REGION]"
     }

--- a/src/command_line/parser.rb
+++ b/src/command_line/parser.rb
@@ -60,6 +60,10 @@ module CommandLine
         options[:is_output_ini] = true
       end
 
+      @opts.on('-z', '--delete_tmp', FalseClass, 'Upon completion, delete the entire deployment_path tmp folder (default false)') do |config|
+        options[:delete_tmp] = true
+      end
+
       return options
     end
 

--- a/src/command_line/provider.rb
+++ b/src/command_line/provider.rb
@@ -23,10 +23,6 @@ module CommandLine
       return @deploy_file_content
     end
 
-    def is_teardown?()
-      return @options[:is_teardown] == true
-    end
-
     def get_user_config_filepath()
       return @options[:user_config]
     end
@@ -61,24 +57,34 @@ module CommandLine
       deployname = get_deploy_config_name()
       return "#{username}-#{deployname}"
     end
-
-    def get_logging_level()
-      return @options[:logging_level].downcase()
-    end
-
     def get_deployment_config(object_class = Hash)
       deploy_config_content = get_deployment_config_content || "{}"
       return JSON.parse(deploy_config_content, object_class: object_class)
     end
 
+    def get_deployment_path()
+      return @deployment_path ||= "#{get_execution_path()}/#{get_deployment_name()}"
+    end
+
+    def get_logging_level()
+      return @options[:logging_level].downcase()
+    end
+
     def get_output_file_path()
       return @options[:output_file_path]
+    end
+    def is_delete_tmp?()
+      return @options[:delete_tmp] == true
     end
 
     def is_output_ini?()
       return @options[:is_output_ini]
     end
-  
+
+    def is_teardown?()
+      return @options[:is_teardown] == true
+    end
+
     private
     def download_file(url, filepath)
       Common::Logger::LoggerFactory.get_logger().debug("Downloading from #{url} to #{filepath}")
@@ -122,19 +128,14 @@ module CommandLine
     end
 
     def is_url?(input)
-      if input!=nil && input.downcase().start_with?("http")
+      if input != nil && input.downcase().start_with?("http")
         return true
       end
       return false
     end
 
-
     def get_execution_path()
       return @execution_path ||= @context.get_app_config_provider().get_execution_path()
-    end
-
-    def get_deployment_path()
-      return @deployment_path ||= "#{get_execution_path()}/#{get_deployment_name()}"
     end
 
   end

--- a/src/user_config/definitions/credential.rb
+++ b/src/user_config/definitions/credential.rb
@@ -43,6 +43,8 @@ module UserConfig
           return nil
         end
 
+        def ensure_created(deployment_path, config_credential)
+        end
     end
   end
 end

--- a/src/user_config/orchestrator.rb
+++ b/src/user_config/orchestrator.rb
@@ -21,10 +21,13 @@ module UserConfig
       log_token = Common::Logger::LoggerFactory.get_logger().add_sub_task('Validating user config')
 
       if user_config_content.nil?
-        command_line_provider = @context.get_command_line_provider()
-        user_config_content = command_line_provider.get_user_config_content()
+        user_config_content = @context.get_command_line_provider().get_user_config_content()
       end
+
       parsed_user_config = @parser.execute(user_config_content)
+      provider = UserConfig::Provider.new(parsed_user_config)
+      deployment_path = @context.get_command_line_provider().get_deployment_path()
+      provider.ensure_all_created(deployment_path)
       if @is_validation_enabled
         validation_errors = @validator.execute(parsed_user_config)
         unless validation_errors.empty?
@@ -32,7 +35,6 @@ module UserConfig
           raise Common::ValidationError.new("User Configuration failed validation:", validation_errors)
         end
       end
-      provider = UserConfig::Provider.new(parsed_user_config)
       @context.set_user_config_provider(provider)
       log_token.success()
       return provider

--- a/src/user_config/provider.rb
+++ b/src/user_config/provider.rb
@@ -16,6 +16,19 @@ module UserConfig
       return nil
     end
 
+    def ensure_all_created(deployment_path)
+      unless @config_file.nil?
+        unless @config_file['credentials'].nil?
+          @config_file['credentials'].each do |item|
+            credential = get_credential(item[0])
+            unless credential.nil?
+              credential.ensure_created(deployment_path, item[1])
+            end
+          end
+        end
+      end
+    end
+
     def get_new_relic_credential()
       return get_credential('newrelic')
     end

--- a/src/user_config/validators/aws/pem_key_validator.rb
+++ b/src/user_config/validators/aws/pem_key_validator.rb
@@ -1,0 +1,40 @@
+require "./src/common/validators/file_exist"
+require "./src/common/validators/validator"
+
+module UserConfig
+  module Validators
+    module Aws
+      class PemKeyValidator
+
+        ERROR_DETAILS = "either 'secretKeyPath' or 'secretKeyName' and 'secretKeyData' must exist"
+        def initialize(error_message = nil)
+          @error_message = error_message || "Invalid Pem key"
+        end
+
+        def execute(aws_configs)
+          keyName = getField(aws_configs, "secretKeyName")
+          keyData = getField(aws_configs, "secretKeyData")
+          keyPath = getField(aws_configs, "secretKeyPath")
+
+          if (keyPath.empty? && (keyName.empty? || keyData.empty?))
+            return "#{@error_message}: #{ERROR_DETAILS}"
+          end
+
+          return nil
+        end
+
+        def getField(configs, field_name)
+          (configs || []).each do |config|
+            unless (config[field_name.to_sym] || "").empty?
+              return config[field_name.to_sym]
+            end
+            unless (config[field_name] || "").empty?
+              return config[field_name]
+            end
+            return ""
+          end
+        end
+      end
+    end
+  end
+end

--- a/src/user_config/validators/aws_validator.rb
+++ b/src/user_config/validators/aws_validator.rb
@@ -1,6 +1,7 @@
 require "./src/common/validators/file_exist"
 require "./src/common/validators/validator"
 require_relative "aws/api_key_validator"
+require_relative "aws/pem_key_validator"
 
 module UserConfig
   module Validators
@@ -10,12 +11,14 @@ module UserConfig
           api_key_exist_validator = nil,
           secret_key_validator = nil,
           region_validator = nil,
-          api_key_validator = nil
+          api_key_validator = nil,
+          pem_key_validator = nil
         )
         @api_key_exist_validator = api_key_exist_validator || Common::Validators::FieldExistValidator.new("apiKey", "apiKey is missing for aws credential:")
         @secret_key_validator = secret_key_validator || Common::Validators::FieldExistValidator.new("secretKey", "secretKey is missing for aws credential:")
         @region_validator = region_validator || Common::Validators::FieldExistValidator.new("region", "region is missing for aws credential:")
         @api_key_validator = api_key_validator || UserConfig::Validators::Aws::ApiKeyValidator.new()
+        @pem_key_validator = pem_key_validator || UserConfig::Validators::Aws::PemKeyValidator.new()
       end
 
       def execute(aws_configs)
@@ -23,7 +26,8 @@ module UserConfig
           lambda { return @api_key_exist_validator.execute(aws_configs) },
           lambda { return @secret_key_validator.execute(aws_configs) },
           lambda { return @region_validator.execute(aws_configs) },
-          lambda { return @api_key_validator.execute(aws_configs) }
+          lambda { return @api_key_validator.execute(aws_configs) },
+          lambda { return @pem_key_validator.execute(aws_configs) }
         ]
 
         validator = Common::Validators::Validator.new(validators)

--- a/tests/user_config/validator_tests.rb
+++ b/tests/user_config/validator_tests.rb
@@ -18,18 +18,18 @@ describe "UserConfig" do
     end
 
     it "should execute credential validator" do
-      given_credential("aws", nil, nil, "/tmp/file.pem")
+      given_credential("aws", nil, nil, nil, nil, "/tmp/file.pem")
       credentials_validator.expects(:execute)
       validator.execute(config)
     end
     
     it "should execute provider_validator_factory" do
-      given_credential("aws", nil, nil, "/tmp/file.pem")
+      given_credential("aws", nil, nil, nil, nil , "/tmp/file.pem")
       provider_validator_factory.expects(:create_validators).returns([])
       validator.execute(config)
     end
 
-    def given_credential(provider, api_key = nil, secret_key = nil, secret_key_path = nil, region = nil)
+    def given_credential(provider, api_key = nil, secret_key = nil, pem_key_name = nil, pem_key_data = nil, pem_key_path = nil, region = nil)
       provider_fields = { }
       unless api_key.nil?
         provider_fields["apiKey"] = api_key
@@ -37,8 +37,14 @@ describe "UserConfig" do
       unless secret_key.nil?
         provider_fields["secretKey"] = secret_key
       end
-      unless secret_key_path.nil?
-        provider_fields["secretKeyPath"] = secret_key_path
+      unless pem_key_name.nil?
+        provider_fields["secretKeyName"] = pem_key_name
+      end
+      unless pem_key_data.nil?
+        provider_fields["secretKeyData"] = pem_key_data
+      end
+      unless pem_key_path.nil?
+        provider_fields["secretKeyPath"] = pem_key_path
       end
       unless region.nil?
         provider_fields["region"] = region

--- a/tests/user_config/validators/aws/pem_key_validator_tests.rb
+++ b/tests/user_config/validators/aws/pem_key_validator_tests.rb
@@ -1,0 +1,70 @@
+require "minitest/spec"
+require "minitest/autorun"
+require 'mocha/minitest'
+
+require "./src/user_config/validators/aws/pem_key_validator"
+
+describe "UserConfig::Validators::Aws::PemKeyValidator" do
+  let(:aws_configs) { [] }
+  let(:error_message_test) { "Error testing" }
+  let(:validator) { UserConfig::Validators::Aws::PemKeyValidator.new(error_message_test) }
+
+  it "should create validator" do
+    validator.wont_be_nil
+  end
+
+  it "should execute pem_key_validator" do
+    given_aws_credential("myPemKeyName", "SuperSecretPrivateKeyData", "/some/path/to/my.pem")
+    validator.execute(aws_configs)
+  end
+
+  it "should error whenever one of name/data is empty, and path is empty " do
+    given_aws_credential("myPemKeyName", nil, nil)
+    errorMessage = validator.execute(aws_configs)
+    errorMessage.wont_be_nil()
+    errorMessage.must_include(error_message_test)
+    errorMessage.must_include(UserConfig::Validators::Aws::PemKeyValidator::ERROR_DETAILS)
+
+    given_aws_credential(nil, "pemData", nil)
+    errorMessage = validator.execute(aws_configs)
+    errorMessage.wont_be_nil()
+    errorMessage.must_include(error_message_test)
+    errorMessage.must_include(UserConfig::Validators::Aws::PemKeyValidator::ERROR_DETAILS)
+  end
+
+  it "should error when pem name, pem data and path are all empty" do
+    given_aws_credential(nil, "pemData", nil)
+    errorMessage = validator.execute(aws_configs)
+    errorMessage.wont_be_nil()
+    errorMessage.must_include(error_message_test)
+    errorMessage.must_include(UserConfig::Validators::Aws::PemKeyValidator::ERROR_DETAILS)
+  end
+
+  it "should pass when pem name and pem data are present" do
+    given_aws_credential("pemName", "pemData", nil)
+    errorMessage = validator.execute(aws_configs)
+    errorMessage.must_be_nil()
+  end
+
+  it "should pass when pem path is present" do
+    given_aws_credential(nil, nil, "/some/pem/path")
+    errorMessage = validator.execute(aws_configs)
+    errorMessage.must_be_nil()
+  end
+
+  def given_aws_credential(pem_key_name = nil, pem_key_data = nil, pem_key_path = nil)
+    aws_config = {}
+    unless pem_key_name.nil?
+      aws_config["secretKeyName"] = pem_key_name
+    end
+    unless pem_key_data.nil?
+      aws_config["secretKeyData"] = pem_key_data
+    end
+    unless pem_key_path.nil?
+      aws_config["secretKeyPath"] = pem_key_path
+    end
+    aws_configs.push(aws_config)
+  end
+
+end # frozen_string_literal: true
+

--- a/tests/user_config/validators/aws_validator_tests.rb
+++ b/tests/user_config/validators/aws_validator_tests.rb
@@ -10,11 +10,13 @@ describe "UserConfig::Validators::AwsValidator" do
   let(:secret_key_validator) { m = mock(); m.stubs(:execute); m }
   let(:region_validator) { m = mock(); m.stubs(:execute); m }
   let(:api_key_validator) { m = mock(); m.stubs(:execute); m }
+  let(:pem_key_validator) { m = mock(); m.stubs(:execute); m }
   let(:validator) { UserConfig::Validators::AwsValidator.new(
     api_key_exist_validator,
     secret_key_validator,
     region_validator,
-    api_key_validator
+    api_key_validator,
+    pem_key_validator
     ) }
 
   it "should create validator" do
@@ -44,6 +46,13 @@ describe "UserConfig::Validators::AwsValidator" do
     api_key_validator.expects(:execute)
     validator.execute(aws_configs)
   end
+
+  it "should execute pem_key_validator" do
+    given_aws_credential("my api key", "my secret key", "my secret key path", "my region")
+    pem_key_validator.expects(:execute)
+    validator.execute(aws_configs)
+  end
+
 
   def given_aws_credential(api_key = nil, secret_key = nil, secret_key_path = nil, region = nil)
     aws_config = { }

--- a/user_acceptance_tests/integration/configuration/deployment_validation_tests.rb
+++ b/user_acceptance_tests/integration/configuration/deployment_validation_tests.rb
@@ -82,7 +82,7 @@ describe "UserAcceptanceTests::Deployment" do
           orchestrator.execute(arguments)
         end
       end
-      error.message.must_include("secret_key_path")
+      error.message.must_include(UserConfig::Validators::Aws::PemKeyValidator::ERROR_DETAILS)
     end
 
     it "should fail on missing region" do


### PR DESCRIPTION
AWS Creds after this update:
```{
  "credentials": {
    "aws": {
      "apiKey": "[env:AWS_ACCESS_KEY_ID]",
      "secretKey": "[env:AWS_SECRET_ACCESS_KEY]",
      "sessionToken": "[env:AWS_SESSION_TOKEN]",
     # 1 - secretKeyName and secretKeyData
      "secretKeyName": "[env:AWS_SECRET_PEM_KEY_NAME]", 
      "secretKeyData": "[env:AWS_SECRET_PEM_KEY_DATA]",
      # 2 - secretKeyPath
      "secretKeyPath": "[env:AWS_SECRET_PEM_KEY_PATH]",
      "region": "[env:AWS_REGION]"
    }
  }
}
```
This change is backwards compatible, but permits us to reference pem key names and private material stored in SSM.  Data retrieved will be used to create a temp file.  No deletion was added as this update is intended to run as an ephemeral Fargate task