### PR TITLE
fix: Deployment name via commandline provider

### DIFF
--- a/src/summary/composer.rb
+++ b/src/summary/composer.rb
@@ -3,13 +3,13 @@ require 'time'
 module Summary
   class Composer
 
-    def execute(provisioned_resources, installed_services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    def execute(provisioned_resources, installed_services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
       summary = ""
 
       summary += get_global_summary(global_instrumentors) unless global_instrumentors.nil? || global_instrumentors.empty?
       summary += "\n"
 
-      summary += get_resource_summary(installed_services, provisioned_resources, resource_instrumentors, deploy_config_url) unless provisioned_resources.nil?
+      summary += get_resource_summary(installed_services, provisioned_resources, resource_instrumentors, deployment_name, deploy_config_url) unless provisioned_resources.nil?
       summary += "\n"
 
       summary += get_service_summary(installed_services, provisioned_resources, service_instrumentors) unless installed_services.nil?
@@ -66,13 +66,13 @@ module Summary
       return output
     end
 
-    def get_resource_summary(installed_services, provisioned_resources, resource_instrumentors, deploy_config_url)
+    def get_resource_summary(installed_services, provisioned_resources, resource_instrumentors, deployment_name, deploy_config_url)
       output = "Deployed Resources:\n\n"
       provisioned_resources.each do |provisioned_resource|
         type = provisioned_resource.get_type()
         provider = provisioned_resource.get_provider()
         resource_id = provisioned_resource.get_id()
-        deployment_name = get_resource_deployment_name(provisioned_resource)
+        deployment_name = get_deployment_name(deployment_name)
         deploy_config_url = get_deploy_config_url(deploy_config_url)
         access_point = get_resource_access_point(provisioned_resource)
         instrumentation_summary = get_instrumentation_summary(resource_id, resource_instrumentors)
@@ -119,12 +119,9 @@ module Summary
       return collection
     end
 
-    def get_resource_deployment_name(provisioned_resource)
+    def get_deployment_name(deployment_name)
       output = ""
-      if provisioned_resource.get_resource().respond_to?(:get_tags)
-        deployment_name = provisioned_resource.get_resource().get_tags()["dxDeploymentName"].to_s
-        output += "deployment name: #{deployment_name}\n" unless deployment_name.empty?
-      end
+      output += "deployment name: #{deployment_name}\n" unless deployment_name.empty?
       return output
     end
 

--- a/src/summary/orchestrator.rb
+++ b/src/summary/orchestrator.rb
@@ -50,9 +50,11 @@ module Summary
       resource_instrumentors = instrumentation_provider.get_all_resource_instrumentors()
       service_instrumentors = instrumentation_provider.get_all_service_instrumentors()
       global_intrumentors = instrumentation_provider.get_all_global_instrumentors()
+
+      deployment_name = @context.get_command_line_provider.get_deployment_name()
       deploy_config_url = @context.get_command_line_provider.get_deploy_config_url()
 
-      composer_result = @summary_composer.execute(provisioned_resources, installed_services, resource_instrumentors, service_instrumentors, global_intrumentors, deploy_config_url)
+      composer_result = @summary_composer.execute(provisioned_resources, installed_services, resource_instrumentors, service_instrumentors, global_intrumentors, deployment_name, deploy_config_url)
 
       summary = "Deployment successful!\n\n"
       summary += "#{composer_result}"

--- a/tests/command_line/provider_tests.rb
+++ b/tests/command_line/provider_tests.rb
@@ -41,6 +41,13 @@ describe "Commandline::Provider" do
       expect(provider.get_deploy_config_name()).must_equal(filename) 
     end
   end
+
+  describe "get_deploy_config_url" do
+    fileurl = "path1/path2/deploy.json"
+    it "should return the deploy_config url" do
+      expect(provider.get_deploy_config_url()).must_equal(fileurl)
+    end
+  end
   
   describe "get_deployment_name" do
     it "should return the deployment name" do

--- a/tests/summary/composer_tests.rb
+++ b/tests/summary/composer_tests.rb
@@ -125,7 +125,7 @@ describe "Summary::Composure" do
     given_service(service1)
     given_provisioned_resource(host_resource)
     summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
-    summary.must_include(deployment_url)
+    summary.must_include(deploy_config_url)
   end
 
   it "should verify composer execute returns service id" do

--- a/tests/summary/composer_tests.rb
+++ b/tests/summary/composer_tests.rb
@@ -54,7 +54,7 @@ describe "Summary::Composure" do
     instrumentor
   }
   let(:deploy_config_url) { "https://example.com/config.json" }
-
+  let(:deployment_name) { "example-instance" }
 
   let(:global_instrumentors) { [] }
   let(:global1) { Instrumentation::Definitions::GlobalInstrumentor.new('id', instrumentation_provider, 'version', 'deploy_script_path', 'source_path') }
@@ -64,7 +64,7 @@ describe "Summary::Composure" do
     given_service(service1)
     given_provisioned_resource(host_resource)
     given_global_instrumentor(global1)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
 
     summary.must_include("id (#{instrumentation_provider})")
   end
@@ -72,7 +72,7 @@ describe "Summary::Composure" do
   it "should verify composer execute does not return global if it is not provided" do
     given_service(service1)
     given_provisioned_resource(host_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
 
     summary.wont_include("Global Instrumentation:")
   end
@@ -82,7 +82,7 @@ describe "Summary::Composure" do
     given_provisioned_resource(host_resource)
     given_global_instrumentor(global1)
     given_global_instrumentor(global2)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
 
     summary.must_include("id (#{instrumentation_provider})")
     summary.must_include("id2 (#{instrumentation_provider})")
@@ -103,34 +103,48 @@ describe "Summary::Composure" do
   it "should verify composer executes with no errors" do
     given_service(service1)
     given_provisioned_resource(host_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.wont_be_empty()
   end
 
   it "should verify composer execute returns the host ip value" do
     given_service(service1)
     given_provisioned_resource(host_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include(ip)
+  end
+
+  it "should verify composer execute returns the deployment name value" do
+    given_service(service1)
+    given_provisioned_resource(host_resource)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
+    summary.must_include(deployment_name)
+  end
+
+  it "should verify composer execute returns the deploy config url value" do
+    given_service(service1)
+    given_provisioned_resource(host_resource)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
+    summary.must_include(deployment_url)
   end
 
   it "should verify composer execute returns service id" do
     given_service(service1)
     given_provisioned_resource(host_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include(app_id)
   end
 
   it "should verify composer execute returns service url" do
     given_service(service1)
     given_provisioned_resource(host_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include("http://"+ip+":"+port.to_s())
   end
 
   it "should output resource url" do
     given_provisioned_resource(elb_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include(elb_url)
   end
 
@@ -138,7 +152,7 @@ describe "Summary::Composure" do
     given_service(service1)
     given_provisioned_resource(host_resource)
     given_instrumented_resource(instrumented_resource)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include(instrumentation_provider)
   end
 
@@ -146,7 +160,7 @@ describe "Summary::Composure" do
     given_service(service1)
     given_provisioned_resource(host_resource)
     given_instrumented_service(instrumented_service)
-    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deploy_config_url)
+    summary = composer.execute(provisioned_resources, services, resource_instrumentors, service_instrumentors, global_instrumentors, deployment_name, deploy_config_url)
     summary.must_include(instrumentation_provider)
   end
 


### PR DESCRIPTION
## Summary

Get the deployment name from the commandline provider. Also adds unit testing for added functions.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [x] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [ ] Deployer version updated

## Deployment Configuration for Testing
https://raw.githubusercontent.com/newrelic/open-install-library/main/test/manual/definitions/infra-agent/debian10-infra.json
