### PR TITLE
feat: Extended output for teardown

### DIFF
--- a/src/teardown/orchestrator.rb
+++ b/src/teardown/orchestrator.rb
@@ -54,8 +54,11 @@ module Teardown
       get_post_actions_orchestrator().execute()
       remove_temporary_resources
 
+      deployment_name = get_deployment_name()
+      deploy_config_url = get_deploy_config_url()
+
       log_token.success()
-      get_summary().execute()
+      get_summary().execute(deployment_name, deploy_config_url)
     end
 
     private
@@ -109,6 +112,14 @@ module Teardown
 
     def is_delete_tmp?
       return @context.get_command_line_provider().is_delete_tmp?()
+    end
+
+    def get_deploy_config_url
+      return @context.get_command_line_provider().get_deploy_config_url()
+    end
+
+    def get_deployment_name
+      return @context.get_command_line_provider().get_deployment_name()
     end
 
     def get_deployment_path

--- a/src/teardown/summary.rb
+++ b/src/teardown/summary.rb
@@ -11,6 +11,7 @@ module Teardown
       summary += "    #{deploy_config_url}" unless deploy_config_url.empty?
 
       Common::Logger::LoggerFactory.get_logger.info(summary)
+      return summary
     end
 
     def get_deploy_config_url(deploy_config_url)

--- a/src/teardown/summary.rb
+++ b/src/teardown/summary.rb
@@ -1,10 +1,28 @@
 module Teardown
   class Summary
 
-    def execute()
+    def execute(deployment_name, deploy_config_url)
       summary = "Teardown successful!\n\n"
+
+      deployment_name = get_deployment_name(deployment_name)
+      deploy_config_url = get_deploy_config_url(deploy_config_url)
+
+      summary += "    #{deployment_name}" unless deployment_name.empty?
+      summary += "    #{deploy_config_url}" unless deploy_config_url.empty?
+
       Common::Logger::LoggerFactory.get_logger.info(summary)
-      return summary
+    end
+
+    def get_deploy_config_url(deploy_config_url)
+      output = ""
+      output += "deploy config url: #{deploy_config_url}\n" unless deploy_config_url.empty?
+      return output
+    end
+
+    def get_deployment_name(deployment_name)
+      output = ""
+      output += "deployment name: #{deployment_name}\n" unless deployment_name.empty?
+      return output
     end
 
   end

--- a/tests/teardown/summary_tests.rb
+++ b/tests/teardown/summary_tests.rb
@@ -1,0 +1,21 @@
+require "minitest/spec"
+require "minitest/autorun"
+require "mocha/minitest"
+
+require "./src/teardown/summary"
+
+describe "Teardown::Summary" do
+    let(:composer) { Teardown::Summary.new() }
+    let(:deployment_name) { "example-instance" }
+    let(:deploy_config_url) { "https://example.com/config.json" }
+
+    it "should include deploy config url" do
+        summary = composer.execute(depoyment_name, deploy_config_url)
+        summary.must_include(deploy_config_url)
+    end
+
+    it "should include deployment name" do
+        summary = composer.execute(deployment_name, deploy_config_url)
+        summary.must_include(deployment_name)
+    end
+end

--- a/tests/teardown/summary_tests.rb
+++ b/tests/teardown/summary_tests.rb
@@ -10,7 +10,7 @@ describe "Teardown::Summary" do
     let(:deploy_config_url) { "https://example.com/config.json" }
 
     it "should include deploy config url" do
-        summary = composer.execute(depoyment_name, deploy_config_url)
+        summary = composer.execute(deployment_name, deploy_config_url)
         summary.must_include(deploy_config_url)
     end
 


### PR DESCRIPTION
## Summary

Extends the output from a deployer teardown run to include the name of the deployment, and the deploy config URL used for the teardown.

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [x] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [ ] Deployer version updated

## Deployment Configuration for Testing
https://raw.githubusercontent.com/newrelic/open-install-library/main/test/manual/definitions/infra-agent/debian10-infra.json