### PR TITLE
chore(aws): update deployer output for ease of creating Cloudwatch Rules

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -13,6 +13,7 @@ rescue Exception => e
   unless e.message.downcase() == "exit"
     Common::Logger::LoggerFactory.get_logger.error(e)
     Common::Logger::LoggerFactory.get_logger.error(e.backtrace)
+    puts "\n{ \"deploy_config_url\":\"#{context.get_command_line_provider.get_deploy_config_filepath}\", \"deployment_action\": \"error\" } \n\n"
   end
   exit(1)
 end

--- a/src/summary/composer.rb
+++ b/src/summary/composer.rb
@@ -127,7 +127,7 @@ module Summary
 
     def get_deploy_config_url(deploy_config_url)
       output = ""
-      output += "deploy config url: #{deploy_config_url}\n" unless deploy_config_url.empty?
+      output += " { \"deploy_config_url\": \"#{deploy_config_url}\", \"deployment_action\": \"provision\" } " unless deploy_config_url.empty?
       return output
     end
 

--- a/src/teardown/summary.rb
+++ b/src/teardown/summary.rb
@@ -16,7 +16,7 @@ module Teardown
 
     def get_deploy_config_url(deploy_config_url)
       output = ""
-      output += "deploy config url: #{deploy_config_url}\n" unless deploy_config_url.empty?
+      output += " { \"deploy_config_url\": \"#{deploy_config_url}\", \"deployment_action\": \"teardown\" } " unless deploy_config_url.empty?
       return output
     end
 


### PR DESCRIPTION
## Summary

Added `deployment_action` text to output on line containing `deploy_config_url`.  Having config and action on a single line allows easier leveraging of EventBridge/Cloudwatch rules

Provisioning:
![Screenshot 2023-11-06 at 10 44 47 AM](https://github.com/newrelic-experimental/deployer/assets/90725916/52df1d4d-94f1-4815-9540-39688160e8ed)

Destroying:
![Screenshot 2023-11-06 at 10 45 06 AM](https://github.com/newrelic-experimental/deployer/assets/90725916/bade9aa9-4cc1-4c94-9ea7-905a0eca950d)

Errors:
![Screenshot 2023-11-07 at 9 05 40 AM](https://github.com/newrelic-experimental/deployer/assets/90725916/70e2be95-7415-46ba-b25d-1a9caf0e6f2e)
