### PR TITLE
chore(security): updated deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Dependencies
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: 3.0.5
           bundler-cache: true
 
       - name: Lint
@@ -32,7 +32,7 @@ jobs:
       - name: Install Dependencies
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: 3.0.5
           bundler-cache: true
 
       - name: Unit Tests
@@ -47,7 +47,7 @@ jobs:
       - name: Install Dependencies
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.4
+          ruby-version: 3.0.5
           bundler-cache: true
 
       - name: Generate Default SSH Keypair

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'aws-sdk-apigateway', '~> 1.0.0.rc7'
+gem 'aws-sdk-apigateway', '~> 1.91.0'
 gem 'minitest', '5.11.3'
 gem 'minitest-hooks', '1.5.0'
 gem 'mocha', '1.8.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.1)
-    aws-eventstream (1.0.3)
-    aws-partitions (1.175.0)
-    aws-sdk-apigateway (1.0.0)
-      aws-sdk-core (~> 3)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-core (3.55.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
-      aws-partitions (~> 1.0)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.887.0)
+    aws-sdk-apigateway (1.91.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
       aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
-    aws-sigv4 (1.1.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sdk-core (3.191.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     equatable (0.5.0)
-    jmespath (1.4.0)
+    jmespath (1.6.2)
     metaclass (0.0.4)
     minitest (5.11.3)
     minitest-hooks (1.5.0)
@@ -54,7 +54,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  aws-sdk-apigateway (~> 1.0.0.rc7)
+  aws-sdk-apigateway (~> 1.91.0)
   minitest (= 5.11.3)
   minitest-hooks (= 1.5.0)
   mocha (= 1.8.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   tty-spinner (= 0.9.3)
 
 BUNDLED WITH
-   1.17.3
+   2.5.6

--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -2,7 +2,7 @@
 setuptools
 
 # Ansible
-ansible-core==2.13.4
+ansible-core==2.16.3
 
 # AWS
 boto3


### PR DESCRIPTION
Seems that updating the dependencies is now causing the GCP UAT test to pass.  Azure still needs some investigation, but this has been busted for a while.

To test, I locally built a deployer image from this PR and successfully provisioned/deprovisioned a few existing linux and windows manual test definitions from OIL