### PR TITLE
fix: Add crowdstrike ansible role to reqs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: newrelic/deployer:${{steps.describe-tags.outputs.TAG}},newrelic/deployer:latest
+          secrets: |
+            "ssh_private_key=${{ secrets.CROWDSTRIKE_REPO_KEY }}"


### PR DESCRIPTION
Fixes `requirements.ansible.private.yml` not being copied over in the build.

Also refactors SSH key logic to use [build secrets](https://docs.docker.com/build/building/secrets/) for security. This will now read the repo key value from the GHA secret `CROWDSTRIKE_REPO_KEY` before pulling the private repo. 

Note that the build will skip installing this private dependency if built without the build secret, keeping it optional when building locally.
