### PR TITLE
fix(ansible): Downgrade core version from 2.16.3 to 2.15.6

### DIFF
--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -2,7 +2,7 @@
 setuptools
 
 # Ansible
-ansible-core==2.15.6
+ansible-core>=2.15.6
 packaging
 requests[security]
 xmltodict

--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -2,7 +2,7 @@
 setuptools
 
 # Ansible
-ansible-core==2.16.3
+ansible-core==2.15.6
 packaging
 requests[security]
 xmltodict


### PR DESCRIPTION
**Issue:-** Non Regression Test for ubuntu 16 were failing because of current ansible-core version compatibility issue with ubuntu 16.04.

![image](https://github.com/user-attachments/assets/6784e493-4517-4cab-a44c-d436055e44aa)

**Fix:-**

Modified ansible-core to restore compatibility with Python 3.5.2, allowing continued support for legacy environments running Ubuntu 16.04 without requiring manual upgrades or alternative configurations.

After fixing the ansible core version, non regression tests passed for ubuntu 16.

![image](https://github.com/user-attachments/assets/eac2b61e-f8a4-4427-ac67-544b518f0141)


[NOTE]: # ( Provide a brief overview of the changes. )

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [ ] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )

## Related Issues
[NOTE]: # ( Provide links to any related Github issues. )

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )

## Reviewers
[NOTE]: # ( Mention reviewers here! )
