### PR TITLE
feat: Added ssm to connect to ec2

### DIFF
--- a/requirements.python.txt
+++ b/requirements.python.txt
@@ -48,6 +48,7 @@ azure-mgmt-datalake-store
 boto3
 botocore
 boto
+awscli
 
 # GCP
 google-auth

--- a/src/common/install/templates/hosts_template_context.rb
+++ b/src/common/install/templates/hosts_template_context.rb
@@ -44,11 +44,31 @@ module Common
           unless @provisioned_resource.nil?
             destination_remote_user = @provisioned_resource.get_user_name()
             destination_ip = @provisioned_resource.get_ip()
+            instance_id = @provisioned_resource.get_param("instance_id")
+            
             if @provisioned_resource.get_resource().is_windows?()
               keyvalues["ansible_password"] = @provisioned_resource.get_param("win_password")
-              keyvalues["ansible_port"] = "5986"
-              keyvalues["ansible_connection"] = "winrm"
-              keyvalues["ansible_winrm_server_cert_validation"] = "ignore"
+              if instance_id && !instance_id.empty?
+                # Use SSM for Windows as well
+                keyvalues["ansible_connection"] = "aws_ssm"
+                keyvalues["ansible_aws_ssm_bucket_name"] = ""  # Optional S3 bucket for session logs
+                keyvalues["ansible_aws_ssm_region"] = @provisioned_resource.get_resource().get_credential().get_region()
+                keyvalues["ansible_shell_type"] = "powershell"
+                destination_ip = instance_id  # Use instance ID as the target instead of IP
+              else
+                # Fallback to WinRM if instance_id is not available
+                keyvalues["ansible_port"] = "5986"
+                keyvalues["ansible_connection"] = "winrm"
+                keyvalues["ansible_winrm_server_cert_validation"] = "ignore"
+              end
+            else
+              # Use SSM Session Manager for Linux instances
+              if instance_id && !instance_id.empty?
+                keyvalues["ansible_connection"] = "aws_ssm"
+                keyvalues["ansible_aws_ssm_bucket_name"] = ""  # Optional S3 bucket for session logs
+                keyvalues["ansible_aws_ssm_region"] = @provisioned_resource.get_resource().get_credential().get_region()
+                destination_ip = instance_id  # Use instance ID as the target instead of IP
+              end
             end
           end
 

--- a/src/infrastructure/definitions/aws/ec2_resource.rb
+++ b/src/infrastructure/definitions/aws/ec2_resource.rb
@@ -60,9 +60,126 @@ module Infrastructure
             [Net.ServicePointManager]::SecurityProtocol = \"tls12, tls\"\n
             (New-Object -TypeName System.Net.WebClient).DownloadFile($url, $file)\n
             powershell.exe -ExecutionPolicy ByPass -File $file\n
+            # Install and start SSM agent\n
+            $ssmAgentUrl = \"https://amazon-ssm-$region.s3.amazonaws.com/latest/windows_amd64/AmazonSSMAgentSetup.exe\"\n
+            $ssmAgentPath = \"$env:temp\\AmazonSSMAgentSetup.exe\"\n
+            (New-Object -TypeName System.Net.WebClient).DownloadFile($ssmAgentUrl, $ssmAgentPath)\n
+            Start-Process -FilePath $ssmAgentPath -ArgumentList \"/S\" -Wait\n
+            Start-Service AmazonSSMAgent\n
           </powershell>"
+          else
+            # Linux user data to ensure SSM agent is installed and running
+            return "#!/bin/bash
+            # Update system and install SSM agent if not present
+            
+            # Function to install SSM agent
+            install_ssm_agent() {
+              # Detect OS and install accordingly
+              if [ -f /etc/os-release ]; then
+                . /etc/os-release
+                OS=$ID
+                VER=$VERSION_ID
+              elif type lsb_release >/dev/null 2>&1; then
+                OS=$(lsb_release -si | tr '[:upper:]' '[:lower:]')
+                VER=$(lsb_release -sr)
+              else
+                OS=$(uname -s)
+              fi
+              
+              case $OS in
+                # Amazon Linux 2
+                amzn|\"amzn\")
+                  yum update -y
+                  yum install -y amazon-ssm-agent
+                  systemctl enable amazon-ssm-agent
+                  systemctl start amazon-ssm-agent
+                  ;;
+                  
+                # Ubuntu/Debian
+                ubuntu|debian)
+                  apt-get update -y
+                  snap install amazon-ssm-agent --classic || {
+                    # Fallback for older Ubuntu versions without snap
+                    wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
+                    dpkg -i amazon-ssm-agent.deb
+                  }
+                  systemctl enable amazon-ssm-agent
+                  systemctl start amazon-ssm-agent
+                  ;;
+                  
+                # RHEL/CentOS/Fedora/Oracle Linux
+                rhel|centos|fedora|ol|\"rhel\"|\"centos\"|\"fedora\"|\"ol\")
+                  yum update -y || dnf update -y
+                  yum install -y amazon-ssm-agent || {
+                    # Download and install manually if not in repo
+                    wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                    rpm -ivh amazon-ssm-agent.rpm
+                  }
+                  systemctl enable amazon-ssm-agent
+                  systemctl start amazon-ssm-agent
+                  ;;
+                  
+                # SUSE/openSUSE
+                sles|opensuse*|suse|\"sles\"|\"opensuse\")
+                  zypper refresh
+                  # Download and install SSM agent manually for SUSE
+                  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                  rpm -ivh amazon-ssm-agent.rpm || zypper install -y ./amazon-ssm-agent.rpm
+                  systemctl enable amazon-ssm-agent
+                  systemctl start amazon-ssm-agent
+                  ;;
+                  
+                # Alpine Linux
+                alpine)
+                  apk update
+                  # SSM agent not officially supported on Alpine, but we can try
+                  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.tar.gz
+                  tar -xzf amazon-ssm-agent.tar.gz
+                  # Manual installation would be complex for Alpine
+                  echo \"Warning: SSM agent installation on Alpine Linux may require manual setup\"
+                  ;;
+                  
+                # Arch Linux
+                arch)
+                  pacman -Syu --noconfirm
+                  # Install from AUR or manual installation
+                  wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.tar.gz
+                  tar -xzf amazon-ssm-agent.tar.gz
+                  # Would need custom installation for Arch
+                  echo \"Warning: SSM agent installation on Arch Linux may require manual setup\"
+                  ;;
+                  
+                *)
+                  echo \"Unknown OS: $OS. Attempting generic installation...\"
+                  # Generic fallback - try to download and install manually
+                  if command -v wget >/dev/null 2>&1; then
+                    wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                    rpm -ivh amazon-ssm-agent.rpm 2>/dev/null || {
+                      # Try tar.gz version
+                      wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.tar.gz
+                      tar -xzf amazon-ssm-agent.tar.gz
+                      echo \"Manual SSM agent setup may be required for this OS\"
+                    }
+                  fi
+                  ;;
+              esac
+            }
+            
+            # Check if SSM agent is already running
+            if ! systemctl is-active --quiet amazon-ssm-agent 2>/dev/null; then
+              echo \"Installing SSM agent...\"
+              install_ssm_agent
+            else
+              echo \"SSM agent is already running\"
+            fi
+            
+            # Final check and restart if needed
+            sleep 10
+            systemctl enable amazon-ssm-agent 2>/dev/null || true
+            systemctl restart amazon-ssm-agent 2>/dev/null || true
+            
+            echo \"SSM agent installation completed\""
           end
-          return nil
         end
 
       end

--- a/src/provision/lookup_templates/aws/ec2/template.erb
+++ b/src/provision/lookup_templates/aws/ec2/template.erb
@@ -69,7 +69,8 @@
       - name: Init the params config
         set_fact:
           params: "{{ (params|default({})) | combine({
-            'ip': item.public_ip_address
+            'ip': item.public_ip_address,
+            'instance_id': item.instance_id
             })
           }}"
         with_items: "{{ ec2_facts.instances }}"

--- a/src/provision/templates/aws/ec2/iam_role.yml
+++ b/src/provision/templates/aws/ec2/iam_role.yml
@@ -1,0 +1,41 @@
+---
+- name: Create IAM role for SSM access
+  amazon.aws.iam_role:
+    aws_access_key: "{{ access_key }}"
+    aws_secret_key: "{{ secret_key }}"
+    aws_session_token: "{{ session_token }}"
+    name: "{{ resource_name }}-ssm-role"
+    assume_role_policy_document: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+    managed_policies:
+      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
+    state: present
+    tags:
+      Name: "{{ resource_name }}-ssm-role"
+  register: iam_role_result
+
+- name: Create IAM instance profile
+  amazon.aws.iam_instance_profile:
+    aws_access_key: "{{ access_key }}"
+    aws_secret_key: "{{ secret_key }}"
+    aws_session_token: "{{ session_token }}"
+    name: "{{ resource_name }}-ssm-profile"
+    roles:
+      - "{{ resource_name }}-ssm-role"
+    state: present
+  register: instance_profile_result
+
+- name: Set instance profile fact
+  set_fact:
+    ssm_instance_profile: "{{ resource_name }}-ssm-profile"

--- a/src/provision/templates/aws/ec2/template.erb
+++ b/src/provision/templates/aws/ec2/template.erb
@@ -22,6 +22,7 @@
 
   tasks:
     - include_tasks: vpc.yml
+    - include_tasks: iam_role.yml
 
     - name: Determine AMI ID for EC2 instance
       amazon.aws.ec2_ami_info:
@@ -63,9 +64,8 @@
           - proto: tcp
             ports:
 <%= ec2[:ports].collect {|port| "            - #{port}" }.join("\n") %>
-            - 22
             cidr_ip: 0.0.0.0/0
-            rule_desc: allow ports
+            rule_desc: allow application ports
 
     - name: Provision AWS EC2 instance - "{{ resource_id }}"
       ec2_instance:
@@ -85,6 +85,7 @@
          state: running
          tags: "{{ tags }}"
          name: "{{ resource_name }}"
+         iam_instance_profile: "{{ ssm_instance_profile }}"
 <% unless ec2[:cpu_credit_specification].nil? %>
          cpu_credit_specification: <%= ec2[:cpu_credit_specification] %>
 <% end %>
@@ -181,7 +182,31 @@
           dest: "{{ artifact_path }}/artifact.json"
       delegate_to: localhost
 
-    - name: wait for SSH to come up
-      local_action: wait_for host={{ item.public_ip_address }} port=22 delay=60 timeout=900 state=started search_regex="OpenSSH"
-      with_items: "{{ ec2.instances }}"
-      when: is_windows == false
+    - name: Wait for SSM agent to initialize
+      pause:
+        seconds: 60
+
+    - name: Wait for SSM connectivity
+      shell: |
+        aws ssm describe-instance-information \
+          --region {{ region }} \
+          --filters "Key=InstanceIds,Values={{ instance_id }}" \
+          --query 'InstanceInformationList[0].PingStatus' \
+          --output text
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ secret_key }}"
+        AWS_SESSION_TOKEN: "{{ session_token }}"
+      register: ssm_status
+      until: ssm_status.stdout == "Online"
+      retries: 30
+      delay: 10
+      failed_when: false
+
+    - name: Display SSM status
+      debug:
+        msg: "SSM Agent Status: {{ ssm_status.stdout | default('Not Available') }}"
+
+    - fail:
+        msg: "SSM Agent failed to come online. Instance may not have proper IAM permissions or SSM agent is not installed."
+      when: ssm_status.stdout != "Online"

--- a/src/teardown/templates/aws/ec2/template.erb
+++ b/src/teardown/templates/aws/ec2/template.erb
@@ -63,3 +63,21 @@
       register: result
       until: result is not failed
       ignore_errors: yes
+
+    - name: Delete IAM instance profile
+      amazon.aws.iam_instance_profile:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_session_token: "{{ aws_session_token }}"
+        name: "{{ resource_name }}-ssm-profile"
+        state: absent
+      ignore_errors: yes
+
+    - name: Delete IAM role
+      amazon.aws.iam_role:
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        aws_session_token: "{{ aws_session_token }}"
+        name: "{{ resource_name }}-ssm-role"
+        state: absent
+      ignore_errors: yes


### PR DESCRIPTION
## Summary

[NOTE]: # ( Provide a brief overview of the changes. )
This removes dependency on the ssh port and uses AWS SSM for connection.
If the SSM is preinstalled then it proceeds with the execution but if the AMI doesn't have the SSM agent preinstalled then on creation of the EC2 using the instance ID the agent is installed on to the EC2 using the userdata().
The 0.0.0.0 IP is still exists but for accessing the applications that are running on the host.
This changes allows the users and ansible to connect to the ec2 

**SSM connection flow:**

`Ansible → AWS SSM Service → EC2 Instance (via instance ID)`

- Ansible calls AWS SSM APIs using the instance ID
- SSM service locates the instance and establishes a session
- No direct network connection to IP needed
- There is a fallback to the old flow using the ssh for ansible incase if the SSM is unavailable.

**SM Agent Installation Strategy:**

_For Linux instances:_

- User data script installs and starts SSM agent if not present
- Handles multiple Linux distributions 
  - ✅ Fully Supported:
    - Amazon Linux 2 - Native yum package
    - Ubuntu/Debian - Snap package + fallback to .deb
    - RHEL/CentOS/Fedora/Oracle Linux - RPM package
    - SUSE/openSUSE - Manual RPM installation with zypper
  - ⚠️ Partial Support:
    - Alpine Linux - Downloads tar.gz but needs manual setup
    - Arch Linux - Downloads tar.gz but needs manual setup
  - 🔄 Generic Fallback:
    - Unknown distributions - Attempts RPM then tar.gz installation
- Amazon Linux 2 comes with SSM agent pre-installed, so it just ensures it's enabled and started
- Other distributions get SSM agent installed via their respective package managers

_For Windows instances:_
User data script downloads and installs SSM agent
Downloads from the official AWS S3 bucket for the specific region
Starts the SSM agent service after installation
Also configures WinRM for backward compatibility (if needed)

_For both:_
Post-provisioning verification waits for SSM agent to come online
Uses AWS CLI to check SSM connectivity status
Fails gracefully with helpful error messages if SSM doesn't come online
Gives sufficient time (up to 5 minutes) for the agent to register with SSM service

## Checklist
[NOTE]: # ( Just check the ones applicable to this pull request. )
- [ ] Documentation updated
- [ ] Unit tests updated
- [ ] Integration tests updated
- [ ] User Acceptance Tests updated
- [ ] Deployer version updated

## Deployment Configuration for Testing
[NOTE]: # ( Provide a deployment configuration to use during manual testing, if applicable. )

## Related Issues
[NOTE]: # ( Provide links to any related Github issues. )

## Related Pull Requests
[NOTE]: # ( Provide links to any related pull requests. )

## Reviewers
[NOTE]: # ( Mention reviewers here! )
