### PR TITLE
feat(app_config): add JP region URLs

### DIFF
--- a/documentation/user_config/newrelic.md
+++ b/documentation/user_config/newrelic.md
@@ -53,7 +53,7 @@ All possible regions are listed below:
 
 - `US`
 - `EU`
-- `AP`
+- `JP`
 
 ### nrOrganizationId
 

--- a/src/app_config.yml
+++ b/src/app_config.yml
@@ -50,6 +50,14 @@ newRelicUrls:
                 identity_url: "https://identity-api.eu.newrelic.com"
                 logging_url: "https://log-api.eu.newrelic.com/log/v1"
                 cloud_collector_url: "https://cloud-collector.eu.newrelic.com"
+        jp:
+                collector_url: "collector.jp.nr-data.net"
+                api_url: "https://api.jp.newrelic.com"
+                infra_collector_url: "https://infra-api.jp.nr-data.net"
+                infra_command_url: "https://infrastructure-command-api.jp.nr-data.net"
+                identity_url: "https://identity-api.jp.nr-data.net"
+                logging_url: "https://log-api.jp.nr-data.net/log/v1"
+                cloud_collector_url: "https://cloud-collector.jp.nr-data.net"
         staging:
                 collector_url: "staging-collector.newrelic.com"
                 api_url: "https://staging-api.newrelic.com"


### PR DESCRIPTION
## Changes

- `src/app_config.yml`: add `jp:` block under `newRelicUrls` with the seven JP URLs (NerdGraph on `api.jp.newrelic.com`; everything else on `*.jp.nr-data.net`).
- `documentation/user_config/newrelic.md`: add `JP` to the list of accepted `nrRegion` values, remove `AP` (added in 2024 but never wired up — same silent-nil failure mode JP had).

## Why

Without a `jp:` block, `app_config_field_merger_builder#with_new_relic_urls` does `urls["jp"]` → `nil`, the `unless region_urls.nil?` guard skips, and recipes get empty `app_config.newrelic.*` values. JP-region installs run "green" but never register data with New Relic.

## Risk

Hash lookup is keyed by region — adding a new key cannot change values for `us`/`eu`/`staging`. Only the JP path changes.

## Post-merge

Trigger `publish.yml` to refresh `newrelic/deployer:latest` on Docker Hub (and verify the `ghcr.io/newrelic/deployer:latest` mirror picks up the change — the newrelic-cli e2e workflow pulls from GHCR).
