### PR TITLE
chore: remove vestigial CrowdStrike Falcon install machinery

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: newrelic/deployer:${{steps.describe-tags.outputs.TAG}},newrelic/deployer:latest
-          secrets: |
-            "ssh_private_key=${{ secrets.CROWDSTRIKE_REPO_KEY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN gem install rexml -v '3.2.5' --source 'https://rubygems.org/'
 
 RUN bundle install --clean --force
 
-COPY requirements.python.txt requirements.ansible.yml requirements.ansible.private.yml /mnt/deployer/
+COPY requirements.python.txt requirements.ansible.yml /mnt/deployer/
 
 RUN python3 -m pip install -r requirements.python.txt
 
@@ -53,23 +53,6 @@ RUN python3 -m pip install -r requirements.txt
 # Install Ansible dependencies
 RUN ansible-galaxy role install -r requirements.ansible.yml && \
     ansible-galaxy collection install -r requirements.ansible.yml
-
-# Install optional private dependencies
-# Build with `--secret id=ssh_private_key,src=/path/to/ssh_private_key` to install private dependencies
-RUN mkdir -p -m 0600 /root/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-RUN --mount=type=secret,id=ssh_private_key \
-    if test -f /run/secrets/ssh_private_key; then \
-    mkdir -p /root/.ssh && \
-    chmod 0700 /root/.ssh && \
-    ssh-keyscan github.com > /root/.ssh/known_hosts && \
-    cat /run/secrets/ssh_private_key > /root/.ssh/id_rsa && \
-    chmod 600 /root/.ssh/id_rsa && \
-    eval `ssh-agent -s` && \
-    ssh-add /root/.ssh/id_rsa && \
-    ansible-galaxy collection install -r requirements.ansible.private.yml  && \
-    rm -rf /root/.ssh; \
-    fi
-
 
 COPY . /mnt/deployer/
 # CMD [ "ruby", "--version"]

--- a/requirements.ansible.private.yml
+++ b/requirements.ansible.private.yml
@@ -1,5 +1,0 @@
----
-collections:
-  # Crowdstrike
-  - name: git@github.com:/newrelic/shared-crowdstrike-ansible-role.git
-    type: git


### PR DESCRIPTION
Per [NR-520645](https://new-relic.atlassian.net/browse/NR-520645) (closed, P2), NR migrated off CrowdStrike Falcon to SentinelOne and asked to decommission Falcon agents from EC2 instances spun up in account 709144918866.

The OIL install role is already a no-op stub (prints `"Skipping CrowdStrike Falcon Sensor installation"`), so the deployer's bundling of `shared-crowdstrike-ansible-role` was already vestigial — the only effect today is that it breaks `publish.yml` whenever the `CROWDSTRIKE_REPO_KEY` deploy key goes stale, as it currently has.

This PR removes the three deployer-side touchpoints: `requirements.ansible.private.yml` (deleted), the `RUN --mount=type=secret,id=ssh_private_key ...` block in `Dockerfile`, and the `secrets:` block in `.github/workflows/publish.yml`. After merge, `publish.yml` no longer needs `CROWDSTRIKE_REPO_KEY`. SentinelOne is not added in this PR — there's no `shared-sentinelone-ansible-role` repo and the ticket scope is decommission-only; if/when it's required on test EC2s, AMI-baking is the natural layer.
